### PR TITLE
Fix missing import in multiagents example

### DIFF
--- a/07-multi-agents/src/multiagents.py
+++ b/07-multi-agents/src/multiagents.py
@@ -1,6 +1,7 @@
 from dotenv import load_dotenv, find_dotenv
 
 import asyncio
+import os
 from llama_index.core.agent.workflow import AgentWorkflow
 from llama_index.core.workflow import Context
 from llama_index.llms.openai import OpenAI


### PR DESCRIPTION
## Summary
- add missing `os` import used to read Tavily API key

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68548c57080c83309a6bd6fc4ac30261